### PR TITLE
Support for --module-path dependencies for compatibility with javafx 9+

### DIFF
--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -524,10 +524,11 @@ def resolve_dependencies(
             except FileExistsError as e:
                 # Do not throw exceptionif target file exists.
                 pass
-    if len(set(modules_deps)) != len(modules_discovered):
-        missing_mods = '\n'.join(x for x in modules_deps - modules_discovered)
-        _logger.info(f"Missing Modules:\n{missing_mods}")
-        raise Exception("Could not discover all modules dependencies")
+    module_set = set(modules_deps)
+    if len(module_set) != len(modules_discovered):
+        missing_mods = '\n'.join(x for x in module_set - modules_discovered)
+        _logger.info("Missing Modules:\n{}".format(missing_mods))
+        raise Exception("Could not discover all module dependencies")
     pathlib.Path(build_success_file).touch(exist_ok=True)
     return primary_endpoint, workspace
 

--- a/jgo/jgo.py
+++ b/jgo/jgo.py
@@ -520,7 +520,7 @@ def resolve_dependencies(
                     modules_discovered.add(dependency_identifier)
                 else:
                     jar_file_in_workspace = os.path.join(workspace, jar_file)
-                link(os.path.join(m2_repo, *g.split('.'), a, version, jar_file), jar_file_in_workspace, link_type=link_type)
+                    link(os.path.join(m2_repo, *g.split('.'), a, version, jar_file), jar_file_in_workspace, link_type=link_type)
             except FileExistsError as e:
                 # Do not throw exceptionif target file exists.
                 pass

--- a/tests/test_parsington.py
+++ b/tests/test_parsington.py
@@ -88,6 +88,25 @@ class ParsingtonTest(unittest.TestCase):
         finally:
             shutil.rmtree(tmp_dir)
 
+    def test_resolve_as_module(self):
+        tmp_dir = tempfile.mkdtemp(prefix='jgo-test-cache-dir')
+        m2_repo = os.path.join(str(pathlib.Path.home()), '.m2', 'repository')
+        try:
+            _, workspace = jgo.resolve_dependencies(
+                PARSINGTON_ENDPOINT,
+                m2_repo=m2_repo,
+                cache_dir=tmp_dir,
+                link_type='auto',
+                modules_deps=[PARSINGTON_ENDPOINT]
+            )
+            jars = glob.glob(os.path.join(workspace, '*jar'))
+            self.assertEqual(len(jars), 0, 'Expected zero jars in workspace')
+            modules = glob.glob(os.path.join(workspace, "modules", '*jar'))
+            self.assertEqual(len(modules), 1, 'Expected one jar in the module directory')
+            self.assertEqual(modules[0], os.path.join(workspace, "modules", 'parsington-%s.jar' % PARSINGTON_VERSION), 'Expected parsington jar')
+        finally:
+            shutil.rmtree(tmp_dir)
+
     def test_run_jgo(self):
         tmp_dir = tempfile.mkdtemp(prefix='jgo-test-cache-dir')
 


### PR DESCRIPTION
In more recent versions of Javafx, the javafx libraries are provided using the module system which was introduced in Java 9. Even when using these dependencies from a project which does not use the module system, it is still required to add the javafx jar files to the `--module-path` instead of the `--classpath`.

I've proposed an additional optional parameter, `--module-dependencies` which accepts a list of artifact coordinates, of the form `groupId:artifactId:version[:classifier]`. When resolving dependencies, jgo will check if any of the discovered dependencies are located in the `module-dependencies` list. If so, it will place these jar files in a subdirectory of the `cache_dir` workspace, named `modules`. This directory will then be specified as a jvm argument as `--module-path ${workspace}/modules`. 

This is not intended to provide full java module system support, but is intended to provide a mechanism for using dependencies which have been built for use with the module system. This also does not handle all of the possible jvm arguments for module configuration, only the --module-path, since the location of the jar files are otherwise unknown to the user when calling `jgo`. Other Module specific arguments should still be passed into jgo the same as any other JVM argument. 

