### PR TITLE
Add additional check to prevent false positive endpoints

### DIFF
--- a/src/jgo/jgo.py
+++ b/src/jgo/jgo.py
@@ -152,6 +152,7 @@ class Endpoint:
             len(endpoint_elements) < 2
             or len(endpoint_elements) > 5
             or endpoint_elements[0].startswith("-")
+            or endpoint_elements[1].startswith("/")
         ):
             return False
 

--- a/src/jgo/jgo.py
+++ b/src/jgo/jgo.py
@@ -152,7 +152,6 @@ class Endpoint:
             len(endpoint_elements) < 2
             or len(endpoint_elements) > 5
             or endpoint_elements[0].startswith("-")
-            or endpoint_elements[1].startswith("/")
         ):
             return False
 

--- a/src/jgo/jgo.py
+++ b/src/jgo/jgo.py
@@ -271,7 +271,7 @@ def run_and_combine_outputs(command, *args):
 
 def find_endpoint(argv, shortcuts={}):
     # endpoint is first positional argument
-    pattern = re.compile("(.*https?://.*|[a-zA-Z]:\\.*)")
+    pattern = re.compile("(.*(https?|grpc)://.*|[a-zA-Z]:\\.*)")
     indices = []
     for index, arg in enumerate(argv):
         if arg in shortcuts or (Endpoint.is_endpoint(arg) and not pattern.match(arg)):


### PR DESCRIPTION
Addresses #92 

This works because it specifically addresses my use case described in #92  (some string of the form `A:/B:C` in the arguments). I am not too happy with the solution because it opens the door to just adding more and more special case checks. Maybe a regular expression check would be better in `Endpoint.is_endpoint`, e.g. something along the lines of
```
[a-z][a-z0-9-_]+[a-z0-9](\.[a-z][a-z0-9-_]+[a-z0-9])
```
Unfortunately, maven is not very specific with their [naming conventions](https://maven.apache.org/guides/mini/guide-naming-conventions.html)