### PR TITLE
Catch exception while copyinng

### DIFF
--- a/src/jgo/jgo.py
+++ b/src/jgo/jgo.py
@@ -710,7 +710,7 @@ def resolve_dependencies(
                     jar_file_in_workspace,
                     link_type=link_type,
                 )
-            except FileExistsError:
+            except (FileExistsError, shutil.SameFileError):
                 # Do not throw exception if target file exists.
                 pass
     pathlib.Path(build_success_file).touch(exist_ok=True)


### PR DESCRIPTION
We came across this issue when running multiple parallel process (`scyjava.start_jvm()`) and from each process,`jgo` is trying to copy the jar files to the same location. 

Since we are already allowing `FileExistsError` to pass, I think we can also allow `shutil.SameFileError` to pass.