### PR TITLE
Test minimum dependency bounds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run tests
         shell: bash
         env:
-          UV_RESOLUTION: ${{ matrix.resolution }}
+          UV_RESOLUTION: ${{ matrix.resolution || 'highest'}}
         run: |
           bin/test.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,13 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }} py${{ matrix.python-version }}${{ matrix.resolution && format(' ({0})', matrix.resolution) || '' }}
+    name: ${{ matrix.os }} py${{ matrix.python-version }}${{ format(' ({0})', matrix.resolution)}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.14']
-        include:
-          - os: ubuntu-latest
-            python-version: '3.10'
-            resolution: lowest
+        resolution: ['lowest', 'highest']
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +76,7 @@ jobs:
       - name: Run tests
         shell: bash
         env:
-          UV_RESOLUTION: ${{ matrix.resolution || 'highest'}}
+          UV_RESOLUTION: ${{ matrix.resolution }}
         run: |
           bin/test.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,17 +69,10 @@ jobs:
         run: |
           uv tool install prysk
 
-      - name: Set up jgo
-        shell: bash
-        env:
-          UV_RESOLUTION: ${{ matrix.resolution }}
-        run: |
-          uv tool install --with-editable ".[cli]" jgo
-
       - name: Run tests
         shell: bash
         env:
-          UV_NO_SYNC: True
+          UV_RESOLUTION: ${{ matrix.resolution }}
         run: |
           bin/test.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,16 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    name: ${{ matrix.os }} py${{ matrix.python-version }}${{ matrix.resolution && format(' ({0})', matrix.resolution) || '' }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.14']
+        include:
+          - os: ubuntu-latest
+            python-version: '3.10'
+            resolution: lowest
 
     steps:
       - uses: actions/checkout@v4
@@ -55,9 +59,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
-          key: ${{ runner.os }}-py${{ matrix.python-version }}-uv-${{ hashFiles('**/pyproject.toml') }}
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-uv-${{ matrix.resolution }}-${{ hashFiles('**/pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-py${{ matrix.python-version }}-uv-
+            ${{ runner.os }}-py${{ matrix.python-version }}-uv-${{ matrix.resolution }}-
 
       - name: Set up uv
         run: |
@@ -74,6 +78,8 @@ jobs:
 
       - name: Run tests
         shell: bash
+        env:
+          UV_RESOLUTION: ${{ matrix.resolution }}
         run: |
           bin/test.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,13 +70,16 @@ jobs:
           uv tool install prysk
 
       - name: Set up jgo
+        shell: bash
+        env:
+          UV_RESOLUTION: ${{ matrix.resolution }}
         run: |
           uv tool install --with-editable ".[cli]" jgo
 
       - name: Run tests
         shell: bash
         env:
-          UV_RESOLUTION: ${{ matrix.resolution }}
+          UV_NO_SYNC: True
         run: |
           bin/test.sh
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ help:
 		docs  - build documentation site locally\n\
 		lint  - run code formatters and linters\n\
 		test  - run automated test suite\n\
+		test-lowest - run tests with lowest dependency resolution\n\
 		dist  - generate release archives\n\
 	"
 
@@ -22,7 +23,10 @@ lint: check
 test: check
 	bin/test.sh
 
+test-lowest: check
+	UV_RESOLUTION=lowest bin/test.sh
+
 dist: check clean
 	bin/dist.sh
 
-.PHONY: help clean docs check lint test dist
+.PHONY: help clean docs check lint test test-lowest dist

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -41,26 +41,5 @@ if [ ${#pytest_args[@]} -gt 0 ]; then
   fi
 fi
 
-# Run prysk if we have args and prysk is installed
-if [ ${#prysk_args[@]} -gt 0 ] && command -v prysk; then
-  # Ensure jgo CLI is available for prysk tests
-  command -v jgo > /dev/null 2>&1 || uv tool install --with-editable ".[cli]" jgo
-
-  # NB: We cannot add prysk to pyproject.toml because
-  # prysk depends on an incompatible version of rich.
-  # Use `uv tool install prysk` instead.
-  #
-  # We set COLOR=never by default to avoid ANSI codes in test output.
-  # We set NO_PROGRESS=1 to disable progress bars in test output.
-  # This is especially important for CI, which may or may not detect
-  # as ANSI-color-compatible compared to local usage of prysk.
-  # Tests can override this (e.g., color.t does).
-  COLOR="${COLOR:-never}" NO_PROGRESS="${NO_PROGRESS:-1}" prysk -v "${prysk_args[@]}"
-  prysk_status=$?
-  if [ $prysk_status -ne 0 ]; then
-    exit_status=$prysk_status
-  fi
-fi
-
 # Exit with appropriate status
 exit $exit_status

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -43,6 +43,9 @@ fi
 
 # Run prysk if we have args and prysk is installed
 if [ ${#prysk_args[@]} -gt 0 ] && command -v prysk; then
+  # Ensure jgo CLI is available for prysk tests
+  command -v jgo > /dev/null 2>&1 || uv tool install --with-editable ".[cli]" jgo
+
   # NB: We cannot add prysk to pyproject.toml because
   # prysk depends on an incompatible version of rich.
   # Use `uv tool install prysk` instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "cjdk>=0.4.0",
-  "psutil>=1",
+  "psutil>=7",
   "requests>=2.16.0",
   "semver>=3.0.0",
   "tomli>=2.0.0; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
   "cjdk>=0.4.0",
   "psutil>=1",
-  "requests",
+  "requests>=2",
   "semver>=3.0.0",
   "tomli>=2.0.0; python_version<'3.11'",
   "tomli-w>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
   "cjdk>=0.4.0",
   "psutil>=7",
+  # Previous versions vendored urllib3/packages/six.py, resulting in failures
   "requests>=2.16.0",
   "semver>=3.0.0",
   "tomli>=2.0.0; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "cjdk>=0.4.0",
-  "psutil",
+  "psutil>=1",
   "requests",
   "semver>=3.0.0",
   "tomli>=2.0.0; python_version<'3.11'",
@@ -56,15 +56,15 @@ cli = [
     "rich-click>=1.9.5",
 ]
 dev = [
-    "build",
-    "mypy",
-    "pytest",
-    "ruff",
-    "types-Pygments",
-    "types-colorama",
-    "types-psutil",
-    "types-requests",
-    "validate-pyproject[all]",
+    "build>=1.2.2",
+    "mypy>=1.20.2",
+    "pytest>=9.0.3",
+    "ruff>=0.15.12",
+    "types-Pygments>=2.20.0",
+    "types-colorama>=0.4.15",
+    "types-psutil>=7.2.2",
+    "types-requests>=2.33.0",
+    "validate-pyproject[all]>=0.25",
     {include-group = "cli"},
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ requires-python = ">=3.10"
 dependencies = [
   "cjdk>=0.4.0",
   "psutil>=1",
-  "requests>=2",
+  "requests>=2.16.0",
   "semver>=3.0.0",
   "tomli>=2.0.0; python_version<'3.11'",
   "tomli-w>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,21 +46,17 @@ dependencies = [
   "urllib3>=2",
 ]
 
-[project.optional-dependencies]
-cli = [
-  "rich>=14.2.0",
-  "rich-click>=1.9.5",
-]
-
 [dependency-groups]
 cli = [
-    "rich>=14.2.0",
+    "rich>=13.3.1",
     "rich-click>=1.9.5",
 ]
 dev = [
     "build>=1.2.2",
     "mypy>=1.20.2",
+    "prysk>=0.20.0",
     "pytest>=9.0.3",
+    "pytest-prysk>=0.4.0",
     "ruff>=0.15.12",
     "types-Pygments>=2.20.0",
     "types-colorama>=0.4.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "semver>=3.0.0",
   "tomli>=2.0.0; python_version<'3.11'",
   "tomli-w>=1.0.0",
+  "urllib3>=2",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Pytest configuration and shared fixtures."""
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -10,6 +11,20 @@ from jgo.util.mvn import ensure_maven_available
 from tests.fixtures.thicket import DEFAULT_SEED, generate_thicket
 
 _BOOTSTRAP_SENTINEL = Path(".cache/m2_repo/.bootstrapped")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prysk_env():
+    """Set default env vars for prysk tests, matching the old shell script invocation."""
+    old = {k: os.environ.get(k) for k in ("COLOR", "NO_PROGRESS")}
+    os.environ.setdefault("COLOR", "never")
+    os.environ.setdefault("NO_PROGRESS", "1")
+    yield
+    for k, v in old.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
It'd be great to verify that jgo works with all of the dependency versions it claims to support. Of course, testing all combinations is infeasible, but we could test other combinations (namely, the minimum bound, in addition to the maximum bounds currently tested)

Note that this PR adds in a number of dependency bounds, namely:
* `psutil>=1` - we just want *a* minimum bound, this one works despite being very old
* All of the dev dependencies - I see no problem with restricting to the current maximum versions?